### PR TITLE
Fix for angular velocity (Y) resetting

### DIFF
--- a/Assets/VRCBilliardsCE/Scripts/PoolStateManager.cs
+++ b/Assets/VRCBilliardsCE/Scripts/PoolStateManager.cs
@@ -2393,7 +2393,16 @@ namespace VRCBilliards
 
                 // Calculate rolling angular velocity
                 W.x = -V.z * BALL_1OR;
-                W.y = 0.0f;
+                
+                if( 0.3f > Mathf.Abs( W.y ) )
+                {
+                    W.y = 0.0f;
+                }
+                else
+                {
+                    W.y -= Mathf.Sign(W.y) * 0.3f;
+                }
+      
                 W.z = V.x * BALL_1OR;
 
                 // Stopping scenario


### PR DESCRIPTION
I mentioned this on twitter but figured I should make a PR for it too.

This fixes the condition where contact velocity reaches 0, but still has angular Y momentum.
Before: ωᵧ = 0
After: △ωᵧ = sgn(ωᵧ) * -0.3

This would heavily effect shots that make use of English/Side against rails.