### PR TITLE
Allow Instance Owners and Room Masters to reset regardless if they are in game or not

### DIFF
--- a/Assets/VRCBilliardsCE/Scripts/PoolCue.asset
+++ b/Assets/VRCBilliardsCE/Scripts/PoolCue.asset
@@ -46,7 +46,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 22
+      Data: 24
     - Name: 
       Entry: 7
       Data: 
@@ -1081,7 +1081,7 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: ownCollider
+      Data: isPickedUp
     - Name: $v
       Entry: 7
       Data: 63|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
@@ -1089,14 +1089,8 @@ MonoBehaviour:
       Entry: 7
       Data: 64|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
-      Entry: 7
-      Data: 65|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: UnityEngine.Collider, UnityEngine.PhysicsModule
-    - Name: 
-      Entry: 8
-      Data: 
+      Entry: 9
+      Data: 37
     - Name: declarationType
       Entry: 3
       Data: 2
@@ -1105,13 +1099,13 @@ MonoBehaviour:
       Data: 0
     - Name: symbolResolvedTypeName
       Entry: 1
-      Data: UnityEngineCollider
+      Data: SystemBoolean
     - Name: symbolOriginalName
       Entry: 1
-      Data: ownCollider
+      Data: isPickedUp
     - Name: symbolUniqueName
       Entry: 1
-      Data: ownCollider
+      Data: isPickedUp
     - Name: symbolDefaultValue
       Entry: 6
       Data: 
@@ -1120,7 +1114,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 66|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 65|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1144,16 +1138,22 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: targetCollider
+      Data: ownCollider
     - Name: $v
       Entry: 7
-      Data: 67|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 66|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 68|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 67|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
-      Entry: 9
-      Data: 65
+      Entry: 7
+      Data: 68|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: UnityEngine.Collider, UnityEngine.PhysicsModule
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: declarationType
       Entry: 3
       Data: 2
@@ -1165,10 +1165,10 @@ MonoBehaviour:
       Data: UnityEngineCollider
     - Name: symbolOriginalName
       Entry: 1
-      Data: targetCollider
+      Data: ownCollider
     - Name: symbolUniqueName
       Entry: 1
-      Data: targetCollider
+      Data: ownCollider
     - Name: symbolDefaultValue
       Entry: 6
       Data: 
@@ -1201,13 +1201,70 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: localPlayerIsInDesktopTopDownView
+      Data: targetCollider
     - Name: $v
       Entry: 7
       Data: 70|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
       Data: 71|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+    - Name: internalType
+      Entry: 9
+      Data: 68
+    - Name: declarationType
+      Entry: 3
+      Data: 2
+    - Name: syncMode
+      Entry: 3
+      Data: 0
+    - Name: symbolResolvedTypeName
+      Entry: 1
+      Data: UnityEngineCollider
+    - Name: symbolOriginalName
+      Entry: 1
+      Data: targetCollider
+    - Name: symbolUniqueName
+      Entry: 1
+      Data: targetCollider
+    - Name: symbolDefaultValue
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: fieldAttributes
+      Entry: 7
+      Data: 72|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: userBehaviourSource
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: localPlayerIsInDesktopTopDownView
+    - Name: $v
+      Entry: 7
+      Data: 73|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: fieldSymbol
+      Entry: 7
+      Data: 74|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 9
       Data: 37
@@ -1234,13 +1291,13 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 72|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 75|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 73|UnityEngine.HideInInspector, UnityEngine.CoreModule
+      Data: 76|UnityEngine.HideInInspector, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -1267,13 +1324,13 @@ MonoBehaviour:
       Data: cuePosConstraint
     - Name: $v
       Entry: 7
-      Data: 74|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 77|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 75|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 78|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 7
-      Data: 76|System.RuntimeType, mscorlib
+      Data: 79|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.Animations.PositionConstraint, UnityEngine.AnimationModule
@@ -1303,7 +1360,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 77|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 80|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -1330,13 +1387,13 @@ MonoBehaviour:
       Data: cueLookAtConstraint
     - Name: $v
       Entry: 7
-      Data: 78|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 81|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 79|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 82|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 7
-      Data: 80|System.RuntimeType, mscorlib
+      Data: 83|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.Animations.LookAtConstraint, UnityEngine.AnimationModule
@@ -1366,7 +1423,70 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 81|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 84|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: userBehaviourSource
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: playerApi
+    - Name: $v
+      Entry: 7
+      Data: 85|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: fieldSymbol
+      Entry: 7
+      Data: 86|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+    - Name: internalType
+      Entry: 7
+      Data: 87|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: VRC.SDKBase.VRCPlayerApi, VRCSDKBase
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: declarationType
+      Entry: 3
+      Data: 2
+    - Name: syncMode
+      Entry: 3
+      Data: 0
+    - Name: symbolResolvedTypeName
+      Entry: 1
+      Data: VRCSDKBaseVRCPlayerApi
+    - Name: symbolOriginalName
+      Entry: 1
+      Data: playerApi
+    - Name: symbolUniqueName
+      Entry: 1
+      Data: playerApi
+    - Name: symbolDefaultValue
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: fieldAttributes
+      Entry: 7
+      Data: 88|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0

--- a/Assets/VRCBilliardsCE/Scripts/PoolMenu.cs
+++ b/Assets/VRCBilliardsCE/Scripts/PoolMenu.cs
@@ -443,6 +443,11 @@ namespace VRCBilliards
 
         private bool HandlePlayerState(TextMeshProUGUI menuText, TextMeshProUGUI scoreText, VRCPlayerApi player)
         {
+            if (!Utilities.IsValid(player))
+            {
+                return false;
+            }
+
             menuText.text = player.displayName;
             scoreText.text = player.displayName;
 

--- a/Assets/VRCBilliardsCE/Scripts/PoolMenu.cs
+++ b/Assets/VRCBilliardsCE/Scripts/PoolMenu.cs
@@ -61,6 +61,8 @@ namespace VRCBilliards
         public TextMeshProUGUI player2MenuText;
         public TextMeshProUGUI player3MenuText;
         public TextMeshProUGUI player4MenuText;
+        public bool instanceOwnerCanReset = true;
+        public bool masterCanReset = false;
 
         [Header("Score")]
         public TextMeshProUGUI player1ScoreText;
@@ -76,6 +78,7 @@ namespace VRCBilliards
         private bool isTeams;
         private bool isSignedUpToPlay;
         private bool canStartGame;
+        private bool canBypass;
 
         // TODO: This all needs to be secured.
         public void UnlockTable()
@@ -185,9 +188,10 @@ namespace VRCBilliards
 
         public void EndGame()
         {
-            if (isSignedUpToPlay)
+            if (isSignedUpToPlay || canBypass)
             {
                 manager.ForceReset();
+                return;
             }
         }
 
@@ -365,10 +369,12 @@ namespace VRCBilliards
                 player4ScoreText.text = "";
             }
 
-            int id = Networking.LocalPlayer.playerId;
+            VRCPlayerApi networkPlayer = Networking.LocalPlayer;
+            int id = networkPlayer.playerId;
             if (id == player1ID || id == player2ID || id == player3ID || id == player4ID)
             {
                 isSignedUpToPlay = true;
+                canBypass = false;
 
                 if (id == player1ID)
                 {
@@ -383,6 +389,16 @@ namespace VRCBilliards
             }
             else
             {
+                if (networkPlayer.isInstanceOwner && instanceOwnerCanReset || networkPlayer.isMaster && masterCanReset)
+                {
+                    canBypass = true;
+                    isSignedUpToPlay = false;
+                    canStartGame = false;
+                    startGameButton.SetActive(false);
+                    return;
+                }
+
+                canBypass = false;
                 isSignedUpToPlay = false;
                 canStartGame = false;
                 startGameButton.SetActive(false);

--- a/Assets/VRCBilliardsCE/Scripts/PoolStateManager.cs
+++ b/Assets/VRCBilliardsCE/Scripts/PoolStateManager.cs
@@ -272,11 +272,6 @@ namespace VRCBilliards
         private AudioSource[] ballPool;
         private AudioSource mainSrc;
 
-        //[UdonSynced]
-        //private string base64NetworkData;
-        //private byte[] newNetworkData = new byte[0x52];
-
-
         /// <summary>
         /// 18:0 (0xffff)	Each bit represents each ball, if it has been pocketed or not
         /// </summary>
@@ -507,8 +502,8 @@ namespace VRCBilliards
 
             CopyGameStateToOldState();
 
-            cueRenderObjs[0].GetComponent<MeshRenderer>().materials[0].SetColor(uniformCueColour, tableBlack);
-            cueRenderObjs[1].GetComponent<MeshRenderer>().materials[0].SetColor(uniformCueColour, tableBlack);
+            cueRenderObjs[0].GetComponent<MeshRenderer>().material.SetColor(uniformCueColour, tableBlack);
+            cueRenderObjs[1].GetComponent<MeshRenderer>().material.SetColor(uniformCueColour, tableBlack);
 
             if (tableReflection != null)
             {


### PR DESCRIPTION
- By default, Instance Owners can reset it, but users who want to allow room masters will have to enable it manually to prevent abuse from room masters, but I added it in anyways so that users can add them. This references #63, but does not close it for now unless we just add a whitelist thingy in where certain users can reset it.

Signed-off-by: Legoman99573 <7460704+Legoman99573@users.noreply.github.com>