### PR TITLE
Fix confusing scrolling with desktop camera

### DIFF
--- a/Assets/VRCBilliardsCE/Scripts/CameraSizeScroller.cs
+++ b/Assets/VRCBilliardsCE/Scripts/CameraSizeScroller.cs
@@ -21,7 +21,7 @@ namespace VRCBilliards
 
         public void Update()
         {
-            float newSize = oldSize + Input.GetAxisRaw("Mouse ScrollWheel") * sensitivity;
+            float newSize = oldSize - Input.GetAxisRaw("Mouse ScrollWheel") * sensitivity;
             if (newSize > upperBound || newSize < lowerBound)
             {
                 return;


### PR DESCRIPTION
Scroll up should zoom in and scroll down should zoom out. This kindof makes it confusing for people, so I flipped the + to a - on line 24 to resolve that without having to change any values on the gameobject itself.