### PR TITLE
Add in UdonChips Save and Load as optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Recommended:
 
 1. CyanEmu for emulating locally (https://github.com/CyanLaser/CyanEmu)
 2. VRWorldToolkit for general world development assistance (https://github.com/oneVR/VRWorldToolkit)
+3. UdonChips in order to allow UdonChips support with the table. Read Below.
+ 
+Optional (not required):
+1. UdonChips SaveAndLoad in order for people to be able to use their chips in your world or specific worlds without having to start over from scratch (https://booth.pm/en/items/3072281)
 
 Installation Steps:
 


### PR DESCRIPTION
This allows people to save and receive a code that they can save before leaving the world. On rejoining, a user would have to put in a code that they saved in order to receive their udon chips back.

Pros:
Coins are tied to the user and can't be used by anyone else.

Cons:
Changing username will void coins (as vrchat doesn't support grabbing the users full ID from the API) and will require starting from scratch.