### PR TITLE
Hotfix: Removed an unused bool array from PoolStateManager

### DIFF
--- a/Assets/VRCBilliardsCE/Scripts/PoolStateManager.cs
+++ b/Assets/VRCBilliardsCE/Scripts/PoolStateManager.cs
@@ -322,11 +322,6 @@ namespace VRCBilliards
         [UdonSynced] private uint ballPocketedState;
 
         /// <summary>
-        ///  Tracks if each ball is pocketed. Easier to read than a bit array.
-        /// </summary>
-        [UdonSynced] private bool[] ballsArePocketed;
-
-        /// <summary>
         /// 19:1 (0x02)		Whos turn is it, 0 or 1
         /// </summary>
         [UdonSynced] private bool newIsTeam2Turn;


### PR DESCRIPTION
Arrays are objects, not primitives, ergo their default value is
null. Udon, in its infinite wisdom, has no guard for what happens
when someone tries to sync a null array. I'm unsure if this is
because the devs forgot the default for an array is null or not,
but regardless it is a nasty bug.

This array is to be used for the slow-boil approach of getting rid
of ballPocketedState, but it's unused right now and is safe to remove.